### PR TITLE
chore: 指定 Node.js 22.x（Vercel）

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
     "postcss": "^8.4.23",
     "tailwindcss": "^3.3.2",
     "vite": "^4.3.2"
+  },
+  "engines": {
+    "node": "22.x"
   }
 }


### PR DESCRIPTION
在 package.json 添加 "engines": { "node": "22.x" }，以确保 Vercel 使用 Node 22 构建与运行，避免旧版 Node 停止支持导致的部署问题。

参考：Vercel 将优先使用 package.json 中的 engines.node 作为构建与运行的 Node 版本。